### PR TITLE
Added basic completion scripts for zsh and bash

### DIFF
--- a/src/isisdl/resources/completions/bash/bash_isisdl
+++ b/src/isisdl/resources/completions/bash/bash_isisdl
@@ -1,4 +1,4 @@
-#! /opt/homebrew/bin/bash
+#! /bin/bash
 
 # Adopted from https://stackoverflow.com/questions/23998364/bash-completion-script-to-complete-file-path-after-certain-arguments-options
 

--- a/src/isisdl/resources/completions/bash/bash_isisdl
+++ b/src/isisdl/resources/completions/bash/bash_isisdl
@@ -1,0 +1,27 @@
+#! /opt/homebrew/bin/bash
+
+# Adopted from https://stackoverflow.com/questions/23998364/bash-completion-script-to-complete-file-path-after-certain-arguments-options
+
+
+_isisdl()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="-h -v -t -d \
+      --help --version --max-num-threads --download-rate \
+      --init --config --sync --compress \
+      --export-config --stream --update \
+      --delete-bad-urls --download-diff"
+
+    if [[ ${prev} == --download-diff ]] ; then
+        compopt -o dirnames 2>/dev/null
+        COMPREPLY=( $(compgen -d -- ${cur}) )
+    elif [[ ${cur} == -* ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _isisdl isisdl
+

--- a/src/isisdl/resources/completions/zsh/_isisdl
+++ b/src/isisdl/resources/completions/zsh/_isisdl
@@ -1,0 +1,20 @@
+#compdef _isisdl isisdl
+
+function _isisdl {
+    _arguments \
+      {-v,--version}'[Prints the version number]' \
+      {-h,--help}'[Shows usage information]' \
+      {-t,--max-num-threads}'[The maximum number of threads to spawn (for downloading files)]: :_guard "[[\:digit\:]]#" "NUMBER"' \
+      {-d,--download-rate}'[Limits the download rate to given number of MiB/s]: :_guard "[[\:digit\:]]#" "NUMBER"' \
+      '--init[Guides you through the initial configuration and setup process]' \
+      '--config[Guides you through additional configuration which focuses on what to download from ISIS]' \
+      '--sync[Do a full reset of the database, updating all file locations and URLs]' \
+      '--compress[Uses ffmpeg to compress all downloaded videos]' \
+      '--export-config[Exports the config to ~/.config/isisdl/export.yaml]' \
+      '--stream[Launches isisdl in streaming mode: It will watch for file accesses and download only those files]' \
+      '--update[Checks for isisdl updates and installs them]' \
+      '--delete-bad-urls[Deletes all urls deemed to be bad, meaning there is no content]' \
+      '--download-diff[Checks if a given directory contains different content than downloaded from isisdl]:directory:_files -/'
+}
+
+


### PR DESCRIPTION
This is the first part of me adding shell completion features to `isisdl` (for zsh and bash shells).
It just adds simple completion scripts which can be installed manually.

The second step would be to integrate an appropriate installer directly into `isisdl --init` (or similar) and will hopefully follow at a later date.