### PR TITLE
fix: permissions of shell completion files

### DIFF
--- a/src/isisdl/utils.py
+++ b/src/isisdl/utils.py
@@ -435,6 +435,10 @@ def startup() -> None:
             completion_source = source_code_location.joinpath("resources", "completions", "zsh", "_isisdl")
             if completion_source.exists():
                 shutil.copy(completion_source, final_path)
+                os.chmod(
+                    os.path.join(final_path, "_isisdl"),
+                    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+                )
 
             # TODO: Also tag this file as autoloadable
 
@@ -448,6 +452,10 @@ def startup() -> None:
             completion_source = source_code_location.joinpath("resources", "completions", "zsh", "_isisdl")
             if completion_source.exists():
                 shutil.copy(completion_source, final_path)
+                os.chmod(
+                    os.path.join(final_path, "_isisdl"),
+                    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+                )
 
 
 def clear() -> None:


### PR DESCRIPTION
This PR adds `os.chown` calls for the shell completion files. This is due to isisdl may be installed in a read-only way (e.g. on NixOS).

This may lead to problems that:
1. `shutil.copy` preserves the ownership flags of the files that are being copied
2. the source shell completion files are read-only; therefore, the shell completion files in `.local/share/...` are read-only
3. on the second run isisdl tries to override shell completions files in .local/share that are read-only; isisdl fails.

This PR simply updates the ownership flags of the copied files in `.local/share/...` to be RW for the owner.

PS: Once this is hopefully merged and released, I'll add isisdl to nixpkgs (NixOS packet manager). :)